### PR TITLE
fix: using jquery approach to replace `.trumbowyg('html')`

### DIFF
--- a/js/src/forum/components/View/SignatureSettings.js
+++ b/js/src/forum/components/View/SignatureSettings.js
@@ -51,7 +51,7 @@ export default class SignatureSettings extends UserPage {
             titleText: app.translator.trans('signature.forum.modal.loading.title'),
             value: app.translator.trans('signature.forum.modal.loading.content'),
         });
-        this.signature = $('.Signature').trumbowyg('html');
+        this.signature = $('.Signature').html();
 
         const data = { signature: this.signature };
 


### PR DESCRIPTION
since its result will be outdated when user is typing CJK chars using IME: https://github.com/Alex-D/Trumbowyg/issues/480